### PR TITLE
Add web interface to utility

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,12 +4,16 @@ import os
 import sys
 from pushbullet import Pushbullet
 
-if len(sys.argv) >= 3:
+
+def create_note(title, content):
     api_key = os.environ["PB_API_KEY"]
     pb = Pushbullet(api_key)
+    pb.push_note(title, content)
+
+
+if len(sys.argv) >= 3:
     title = sys.argv[1]
     body = sys.argv[2]
-    
-    pb.push_note(title, body)
+    create_note(title, body)
 else:
     print("Error: Missing arguments")

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import os
 from pushbullet import Pushbullet
 
 
+@hug.get()
 @hug.cli()
 def create_note(title: hug.types.text, content: hug.types.text):
     api_key = os.environ["PB_API_KEY"]

--- a/app.py
+++ b/app.py
@@ -1,19 +1,16 @@
 #!notify/bin/python3
 
+import hug
 import os
-import sys
 from pushbullet import Pushbullet
 
 
-def create_note(title, content):
+@hug.cli()
+def create_note(title: hug.types.text, content: hug.types.text):
     api_key = os.environ["PB_API_KEY"]
     pb = Pushbullet(api_key)
     pb.push_note(title, content)
 
 
-if len(sys.argv) >= 3:
-    title = sys.argv[1]
-    body = sys.argv[2]
-    create_note(title, body)
-else:
-    print("Error: Missing arguments")
+if __name__ == '__main__':
+    create_note.interface.cli()


### PR DESCRIPTION
The server can be started and used like so:

```sh
hug -f app.py

title="foo"
content="bar"
curl "http://localhost:8000/create_note?title=${title}&content=${content}"
```

The command line functionality remains unchanged:

```sh
title="foo"
content="bar"
python app.py "${title}" "${content}"
```

Resolves #1